### PR TITLE
Feature: Add N + 1 detection support

### DIFF
--- a/cli/src/main/scala/tailcall/cli/CommandADT.scala
+++ b/cli/src/main/scala/tailcall/cli/CommandADT.scala
@@ -9,14 +9,15 @@ sealed trait CommandADT extends Serializable with Product
 
 object CommandADT {
   final case class BlueprintOptions(blueprint: Boolean, endpoints: Boolean, schema: Boolean)
-  final case class Check(config: ::[Path], url: Option[URL], options: BlueprintOptions) extends CommandADT
+  final case class Check(config: ::[Path], url: Option[URL], nPlusOne: Boolean, options: BlueprintOptions)
+      extends CommandADT
   final case class Generate(
     files: ::[Path],
     sourceFormat: SourceFormat,
     targetFormat: TargetFormat,
     write: Option[Path],
   ) extends CommandADT
-  final case class Remote(server: URL, command: Remote.Command)                         extends CommandADT
+  final case class Remote(server: URL, command: Remote.Command) extends CommandADT
   object Remote {
     sealed trait Command
     final case class Publish(config: ::[Path])                       extends Command

--- a/cli/src/main/scala/tailcall/cli/CommandDoc.scala
+++ b/cli/src/main/scala/tailcall/cli/CommandDoc.scala
@@ -7,10 +7,16 @@ import zio.cli._
 object CommandDoc {
 
   val command: Command[CommandADT] = Command("tc", Options.none).subcommands(
-    Command("check", CustomOptions.remoteOption.optional ++ CustomOptions.blueprintOptions, Args.file.repeat1)
-      .withHelp("Validate a composition spec, display its status when remote is passed.").map {
-        case (remote, blueprintOptions) -> config => CommandADT.Check(config, remote, blueprintOptions)
-      },
+    Command(
+      "check",
+      CustomOptions.remoteOption.optional ++
+        Options.boolean("nPlusOne").alias("npo") ++
+        CustomOptions.blueprintOptions,
+      Args.file.repeat1,
+    ).withHelp("Validate a composition spec, display its status when remote is passed.").map {
+      case (remote, nPlusOne, blueprintOptions) -> config => CommandADT
+          .Check(config, remote, nPlusOne, blueprintOptions)
+    },
 
     // publish
     Command("publish", CustomOptions.remoteOption, Args.file.repeat1)

--- a/cli/src/main/scala/tailcall/cli/CustomOptions.scala
+++ b/cli/src/main/scala/tailcall/cli/CustomOptions.scala
@@ -7,6 +7,24 @@ import zio.http.URL
 
 object CustomOptions {
 
+  val remoteOption: Options[URL] = CustomOptions.urlOption("remote").alias("r")
+
+  val blueprintOptions: Options[BlueprintOptions] = {
+    Options.boolean("blueprint").withDefault(false) ++
+      Options.boolean("endpoints").withDefault(false) ++
+      Options.boolean("schema").alias("s").withDefault(false)
+  }.map(BlueprintOptions.tupled)
+
+  val sourceFormat: Options[SourceFormat] = Options
+    .enumeration("source")(SourceFormat.Postman.named, SourceFormat.SchemaDefinitionLanguage.named)
+
+  val targetFormat: Options[TargetFormat] = Options.enumeration("target")(
+    TargetFormat.Config(ConfigFormat.JSON).named,
+    TargetFormat.Config(ConfigFormat.YML).named,
+    TargetFormat.Config(ConfigFormat.GRAPHQL).named,
+    TargetFormat.JsonLines.named,
+  )
+
   def integerOption(name: String): Options[Int] =
     Options.text(name).mapOrFail { int =>
       if ("^[0-9]+$".r.matches(int)) Right(int.toInt)
@@ -20,19 +38,4 @@ object CustomOptions {
         case Right(value) => Right(value)
       }
     }
-
-  val remoteOption: Options[URL] = CustomOptions.urlOption("remote").alias("r")
-
-  val blueprintOptions = (Options.boolean("blueprint").withDefault(false) ++ Options.boolean("endpoints")
-    .withDefault(false) ++ Options.boolean("schema").alias("s").withDefault(false)).map(BlueprintOptions.tupled)
-
-  val sourceFormat: Options[SourceFormat] = Options
-    .enumeration("source")(SourceFormat.Postman.named, SourceFormat.SchemaDefinitionLanguage.named)
-
-  val targetFormat: Options[TargetFormat] = Options.enumeration("target")(
-    TargetFormat.Config(ConfigFormat.JSON).named,
-    TargetFormat.Config(ConfigFormat.YML).named,
-    TargetFormat.Config(ConfigFormat.GRAPHQL).named,
-    TargetFormat.JsonLines.named,
-  )
 }

--- a/cli/src/main/scala/tailcall/cli/service/CommandExecutor.scala
+++ b/cli/src/main/scala/tailcall/cli/service/CommandExecutor.scala
@@ -93,7 +93,7 @@ object CommandExecutor {
     private def blueprintDetails(blueprint: Blueprint, options: BlueprintOptions): ZIO[Any, IOException, Unit] = {
       for {
         _ <- Console.printLine(Fmt.heading("Blueprint:\n") ++ Fmt.blueprint(blueprint)).when(options.blueprint)
-        _ <- Console.printLine(Fmt.heading("GraphQL Schema:\n") ++ Fmt.graphQL(graphQLGen.toGraphQL(blueprint)))
+        _ <- Console.printLine(Fmt.heading("GraphQL Schema:\n") ++ Fmt.graphQL(graphQLGen.toGraphQL(blueprint.sorted)))
           .when(options.schema)
         _ <- Console.printLine(Fmt.heading("Endpoints:\n") ++ endpoints(blueprint.endpoints)).when(options.endpoints)
 

--- a/cli/src/main/scala/tailcall/cli/service/CommandExecutor.scala
+++ b/cli/src/main/scala/tailcall/cli/service/CommandExecutor.scala
@@ -26,10 +26,18 @@ object CommandExecutor {
 
   def default: ZLayer[Any, Throwable, CommandExecutor] = { Env.default >>> live }
 
-  def live: ZLayer[Env, Nothing, CommandExecutor] = ZLayer.fromFunction(Live.apply _)
-
   def execute(command: CommandADT): ZIO[CommandExecutor, Nothing, ExitCode] =
     ZIO.serviceWithZIO[CommandExecutor](_.dispatch(command))
+
+  def live: ZLayer[Env, Nothing, CommandExecutor] = ZLayer.fromFunction(Live.apply _)
+
+  private def nPlusOneData(nPlusOne: Boolean, config: Config, seq: Seq[(String, String)]) = {
+    ZIO.succeed(
+      if (nPlusOne)
+        seq :+ ("N + 1"    -> (config.nPlusOne.length.toString + Fmt.nPlusOne(config.nPlusOne.map(_.map(_._2)))))
+      else seq :+ ("N + 1" -> config.nPlusOne.length.toString)
+    )
+  }
 
   final private case class Live(
     graphQLGen: GraphQLGenerator,
@@ -43,8 +51,8 @@ object CommandExecutor {
         command match {
           case CommandADT.Generate(files, sourceFormat, targetFormat, write) =>
             runGenerate(files, sourceFormat, targetFormat, write)
-          case CommandADT.Check(files, remote, options)                      => runCheck(files, remote, options)
-          case CommandADT.Remote(base, command)                              => command match {
+          case CommandADT.Check(files, remote, nPlusOne, options) => runCheck(files, remote, nPlusOne, options)
+          case CommandADT.Remote(base, command)                   => command match {
               case Remote.Publish(path)          => runRemotePublish(base, path)
               case Remote.Drop(digest)           => runRemoteDrop(base, digest)
               case Remote.ListAll(index, offset) => runRemoteList(base, index, offset)
@@ -88,6 +96,7 @@ object CommandExecutor {
         _ <- Console.printLine(Fmt.heading("GraphQL Schema:\n") ++ Fmt.graphQL(graphQLGen.toGraphQL(blueprint)))
           .when(options.schema)
         _ <- Console.printLine(Fmt.heading("Endpoints:\n") ++ endpoints(blueprint.endpoints)).when(options.endpoints)
+
       } yield ()
     }
 
@@ -118,25 +127,31 @@ object CommandExecutor {
       } yield out
     }
 
-    private def runCheck(files: ::[Path], remote: Option[URL], options: BlueprintOptions): ZIO[Any, Throwable, Unit] = {
+    private def runCheck(
+      files: ::[Path],
+      remote: Option[URL],
+      nPlusOne: Boolean,
+      options: BlueprintOptions,
+    ): ZIO[Any, Throwable, Unit] = {
       for {
         config    <- configFile.readAll(files.map(_.toFile))
         blueprint <- config.toBlueprint.toZIO.mapError(ValidationError.BlueprintGenerationError)
         digest = blueprint.digest
-        seq0   = Seq(
+        seq    = Seq(
           "Digest"    -> s"${digest.hex}",
           "Endpoints" -> blueprint.endpoints.length.toString,
-          "Unsafe"    -> config.unsafeCount.toString,
+          "Unsafe"    -> config.unsafeSteps.length.toString,
         )
-        seq1 <- remote match {
+        seq <- remote match {
           case Some(remote) => registry.get(remote, digest).map {
-              case Some(_) => seq0 :+ ("Playground", Fmt.playground(remote, digest))
-              case None    => seq0 :+ ("Playground" -> "Unavailable")
+              case Some(_) => seq :+ ("Playground", Fmt.playground(remote, digest))
+              case None    => seq :+ ("Playground" -> "Unavailable")
             }
-          case None         => ZIO.succeed(seq0)
+          case None         => ZIO.succeed(seq)
         }
+        seq <- nPlusOneData(nPlusOne, config, seq)
         _ <- Console.printLine(Fmt.success("No errors found."))
-        _ <- Console.printLine(Fmt.table(seq1))
+        _ <- Console.printLine(Fmt.table(seq))
         _ <- blueprintDetails(blueprint, options)
       } yield ()
     }
@@ -182,12 +197,14 @@ object CommandExecutor {
         blueprint <- config.toBlueprint.toZIO.mapError(ValidationError.BlueprintGenerationError)
         digest    <- registry.add(base, blueprint)
         _         <- Console.printLine(Fmt.success("Deployment was completed successfully."))
-        _         <- Console.printLine(Fmt.table(Seq(
+        seq       <- ZIO.succeed(Seq(
           "Digest"     -> s"${digest.hex}",
           "Endpoints"  -> blueprint.endpoints.length.toString,
-          "Unsafe"     -> config.unsafeCount.toString,
+          "Unsafe"     -> config.unsafeSteps.length.toString,
           "Playground" -> Fmt.playground(base, digest),
-        )))
+        ))
+        seq       <- nPlusOneData(false, config, seq)
+        _         <- Console.printLine(Fmt.table(seq))
       } yield ()
     }
 
@@ -219,14 +236,6 @@ object CommandExecutor {
       Fmt.table(blueprints.zipWithIndex.map { case (blueprint, index) => ((index + 1).toString, blueprint.digest.hex) })
     }
 
-    def table(labels: Seq[(String, String)]): String = {
-      def maxLength = labels.map(_._1.length).max + 1
-      def padding   = " " * maxLength
-      labels.map { case (key, value) => heading((key + ":" + padding).take(maxLength)) + " " ++ value }.mkString("\n")
-    }
-
-    def heading(str: String): String = fansi.Str(str).overlay(fansi.Bold.On).render
-
     def caption(str: String): String = fansi.Str(str).overlay(fansi.Color.DarkGray).render
 
     def error(message: String): String = fansi.Str(message).overlay(fansi.Color.Red).render
@@ -241,10 +250,27 @@ object CommandExecutor {
 
     def graphQL(graphQL: GraphQL[_]): String = { graphQL.render }
 
+    def heading(str: String): String = fansi.Str(str).overlay(fansi.Bold.On).render
+
     def meta(str: String): String = fansi.Str(str).overlay(fansi.Color.LightYellow).render
+
+    def nPlusOne(list: List[List[String]]): String =
+      meta(
+        list.sortBy(_.mkString("_")).map { path =>
+          "  query { " + path.foldRight("") { case (value, acc) =>
+            if (acc.isEmpty) value else s"${value} { ${acc} }"
+          } + " }"
+        }.mkString("\n", "\n", "")
+      )
 
     def playground(url: URL, digest: Digest): String = s"${url.encode}/graphql/${digest.hex}."
 
     def success(str: String): String = fansi.Str(str).overlay(fansi.Color.Green).render
+
+    def table(labels: Seq[(String, String)]): String = {
+      def maxLength = labels.map(_._1.length).max + 1
+      def padding   = " " * maxLength
+      labels.map { case (key, value) => heading((key + ":" + padding).take(maxLength)) + " " ++ value }.mkString("\n")
+    }
   }
 }

--- a/runtime/src/main/scala/tailcall/runtime/model/Config.scala
+++ b/runtime/src/main/scala/tailcall/runtime/model/Config.scala
@@ -136,7 +136,7 @@ final case class Config(version: Int = 0, server: Server = Server(), graphQL: Gr
         case Some(typeOf) => typeOf.fields.toList.flatMap { case (name, field) =>
             val newPath = path :+ (typeName, name)
             if (path.contains((typeName, name))) List.empty
-            else if (field.hasResolver && isList) List(newPath)
+            else if (field.hasResolver && !field.hasBatchedResolver && isList) List(newPath)
             else findFanOut(field.typeOf, newPath, field.isList || isList)
           }
         case None         => List.empty
@@ -448,7 +448,9 @@ object Config {
       input: Option[TSchema] = None,
       output: Option[TSchema] = None,
       body: Option[String] = None,
-    ): Field = withHttp(Http(path, method, Option(query), input, output, body))
+      groupBy: List[String] = Nil,
+      batchKey: Option[String] = None,
+    ): Field = withHttp(Http(path, method, Option(query), input, output, body, Option(groupBy), batchKey))
 
     def withInline(path: String*): Field = copy(inline = Option(InlineType(path.toList)))
 

--- a/runtime/src/main/scala/tailcall/runtime/model/Config.scala
+++ b/runtime/src/main/scala/tailcall/runtime/model/Config.scala
@@ -135,7 +135,8 @@ final case class Config(version: Int = 0, server: Server = Server(), graphQL: Gr
       findType(typeName) match {
         case Some(typeOf) => typeOf.fields.toList.flatMap { case (name, field) =>
             val newPath = path :+ (typeName, name)
-            if (field.hasResolver && isList) List(newPath)
+            if (path.contains((typeName, name))) List.empty
+            else if (field.hasResolver && isList) List(newPath)
             else findFanOut(field.typeOf, newPath, field.isList || isList)
           }
         case None         => List.empty

--- a/runtime/src/main/scala/tailcall/runtime/model/Config.scala
+++ b/runtime/src/main/scala/tailcall/runtime/model/Config.scala
@@ -374,16 +374,6 @@ object Config {
     def asRequired: Field = copy(required = Option(true))
 
     def compress: Field = {
-      val isList = self.list match {
-        case Some(true) => Some(true)
-        case _          => None
-      }
-
-      val isRequired = self.required match {
-        case Some(true) => Some(true)
-        case _          => None
-      }
-
       val steps = self.unsafeSteps match {
         case Some(steps) if steps.nonEmpty => Option(steps.map(_.compress))
         case _                             => None
@@ -394,24 +384,14 @@ object Config {
         case _                           => None
       }
 
-      val modify = self.modify match {
-        case Some(value) if value.nonEmpty => Some(value)
-        case _                             => None
-      }
-
-      val inline = self.inline match {
-        case Some(value) if value.path.nonEmpty => Some(value)
-        case _                                  => None
-      }
-
       copy(
-        list = isList,
-        required = isRequired,
+        list = self.list.filter(_ == true),
+        required = self.required.filter(_ == true),
         unsafeSteps = steps,
         args = args,
-        modify = modify,
-        http = http,
-        inline = inline,
+        modify = self.modify.filter(_.nonEmpty),
+        http = http.map(_.compress),
+        inline = self.inline.filter(_.path.nonEmpty),
       )
     }
 

--- a/runtime/src/main/scala/tailcall/runtime/model/UnsafeSteps.scala
+++ b/runtime/src/main/scala/tailcall/runtime/model/UnsafeSteps.scala
@@ -56,9 +56,10 @@ object UnsafeSteps {
     ) extends Operation {
       self =>
       override def compress: Http = {
-        val method = self.method.filterNot(_ == Method.GET)
-        val query  = self.query.filter(_.nonEmpty)
-        self.copy(method = method, query = query)
+        val method  = self.method.filterNot(_ == Method.GET)
+        val query   = self.query.filter(_.nonEmpty)
+        val groupBy = self.groupBy.filter(_.nonEmpty)
+        self.copy(method = method, query = query, groupBy = groupBy)
       }
 
       def withBatchKey(batchKey: String): Http = copy(batchKey = Option(batchKey))

--- a/runtime/src/test/scala/tailcall/runtime/ConfigSpec.scala
+++ b/runtime/src/test/scala/tailcall/runtime/ConfigSpec.scala
@@ -2,6 +2,7 @@ package tailcall.runtime
 
 import tailcall.runtime.model.Config.{Field, Type}
 import tailcall.runtime.model.UnsafeSteps.Operation
+import tailcall.runtime.model.UnsafeSteps.Operation.Http
 import tailcall.runtime.model.{Config, Path, TSchema}
 import zio.test.{ZIOSpecDefault, assertTrue}
 
@@ -24,6 +25,17 @@ object ConfigSpec extends ZIOSpecDefault {
           )
           val actual   = config.nPlusOne
           val expected = List(List("Query" -> "f1", "F1" -> "f2"))
+          assertTrue(actual == expected)
+        },
+        test("with batched resolvers") {
+          val http     = Http.fromPath("/f2").withGroupBy("a").withBatchKey("b")
+          val config   = Config.default(
+            "Query" -> Type("f1" -> Field.ofType("F1").asList.resolveWith(0)),
+            "F1"    -> Type("f2" -> Field.ofType("F2").asList.withHttp(http)),
+            "F2"    -> Type("f3" -> Field.str),
+          )
+          val actual   = config.nPlusOne
+          val expected = List()
           assertTrue(actual == expected)
         },
         test("with nested resolvers") {

--- a/runtime/src/test/scala/tailcall/runtime/ConfigSpec.scala
+++ b/runtime/src/test/scala/tailcall/runtime/ConfigSpec.scala
@@ -1,17 +1,63 @@
 package tailcall.runtime
 
-import tailcall.runtime.model.Config.Field
+import tailcall.runtime.model.Config.{Field, Type}
 import tailcall.runtime.model.UnsafeSteps.Operation
 import tailcall.runtime.model.{Config, Path, TSchema}
 import zio.test.{ZIOSpecDefault, assertTrue}
 
 object ConfigSpec extends ZIOSpecDefault {
   def spec =
-    suite("ConfigSpec")(suite("compression")(test("http with schema") {
-      val step     = Operation.Http(path = Path.unsafe.fromString("/foo"), output = Option(TSchema.str))
-      val config   = Config.default.withTypes("Query" -> Config.Type("foo" -> Field.ofType("String").withSteps(step)))
-      val actual   = config.compress
-      val expected = config
-      assertTrue(actual == expected)
-    }))
+    suite("ConfigSpec")(suite("compression")(
+      test("http with schema") {
+        val step     = Operation.Http(path = Path.unsafe.fromString("/foo"), output = Option(TSchema.str))
+        val config   = Config.default.withTypes("Query" -> Config.Type("foo" -> Field.ofType("String").withSteps(step)))
+        val actual   = config.compress
+        val expected = config
+        assertTrue(actual == expected)
+      },
+      suite("n + 1")(
+        test("with resolvers") {
+          val config   = Config.default(
+            "Query" -> Type("f1" -> Field.ofType("F1").asList.resolveWith(0)),
+            "F1"    -> Type("f2" -> Field.ofType("F2").asList.resolveWith(0)),
+            "F2"    -> Type("f3" -> Field.str),
+          )
+          val actual   = config.nPlusOne
+          val expected = List(List("Query" -> "f1", "F1" -> "f2"))
+          assertTrue(actual == expected)
+        },
+        test("with nested resolvers") {
+          val config   = Config.default(
+            "Query" -> Type("f1" -> Field.ofType("F1").asList.resolveWith(0)),
+            "F1"    -> Type("f2" -> Field.ofType("F2").asList),
+            "F2"    -> Type("f3" -> Field.ofType("F3").asList),
+            "F3"    -> Type("f4" -> Field.str.resolveWith(0)),
+          )
+          val actual   = config.nPlusOne
+          val expected = List(List("Query" -> "f1", "F1" -> "f2", "F2" -> "f3", "F3" -> "f4"))
+          assertTrue(actual == expected)
+        },
+        test("with nested resolvers non list resolvers") {
+          val config   = Config.default(
+            "Query" -> Type("f1" -> Field.ofType("F1").resolveWith(0)),
+            "F1"    -> Type("f2" -> Field.ofType("F2").asList),
+            "F2"    -> Type("f3" -> Field.ofType("F3").asList),
+            "F3"    -> Type("f4" -> Field.str.resolveWith(0)),
+          )
+          val actual   = config.nPlusOne
+          val expected = List(List("Query" -> "f1", "F1" -> "f2", "F2" -> "f3", "F3" -> "f4"))
+          assertTrue(actual == expected)
+        },
+        test("without resolvers") {
+          val config   = Config.default(
+            "Query" -> Type("f1" -> Field.ofType("F1").asList.resolveWith(0)),
+            "F1"    -> Type("f2" -> Field.ofType("F2").asList),
+            "F2"    -> Type("f3" -> Field.str),
+          )
+          val actual   = config.nPlusOne
+          val expected = List()
+          assertTrue(actual == expected)
+        },
+      ),
+    ))
 }

--- a/runtime/src/test/scala/tailcall/runtime/ConfigSpec.scala
+++ b/runtime/src/test/scala/tailcall/runtime/ConfigSpec.scala
@@ -58,6 +58,25 @@ object ConfigSpec extends ZIOSpecDefault {
           val expected = List()
           assertTrue(actual == expected)
         },
+        test("cycles") {
+          val config   = Config.default(
+            "Query" -> Type("f1" -> Field.ofType("F1").asList.resolveWith(0)),
+            "F1"    -> Type("f1" -> Field.ofType("F1"), "f2" -> Field.ofType("F2").asList),
+            "F2"    -> Type("f3" -> Field.str),
+          )
+          val actual   = config.nPlusOne
+          val expected = List()
+          assertTrue(actual == expected)
+        },
+        test("cycles with resolvers") {
+          val config   = Config.default(
+            "Query" -> Type("f1" -> Field.ofType("F1").asList.resolveWith(0)),
+            "F1"    -> Type("f1" -> Field.ofType("F1").asList, "f2" -> Field.str.resolveWith(0)),
+          )
+          val actual   = config.nPlusOne
+          val expected = List(List("Query" -> "f1", "F1" -> "f1", "F1" -> "f2"), List("Query" -> "f1", "F1" -> "f2"))
+          assertTrue(actual == expected)
+        },
       ),
     ))
 }

--- a/runtime/src/test/scala/tailcall/runtime/transcoder/ConfigSDLIdentitySpec.scala
+++ b/runtime/src/test/scala/tailcall/runtime/transcoder/ConfigSDLIdentitySpec.scala
@@ -228,7 +228,7 @@ object ConfigSDLIdentitySpec extends ZIOSpecDefault {
           ),
         )
 
-        assertIdentity(config, graphQL)
+        assertIdentity(config.compress, graphQL)
       },
       test("invalid directive on field") {
         val graphQL = """


### PR DESCRIPTION
- fix: bug in inlining scalar fields (#132)
- test: add inline tests into a suite
- refactor: add unit operator to TValid
- fix: handle required type while inlining values from a list type
- refactor: rename method on Config
- chore(deps): update dependency sbt/sbt to v1.8.3 (#133)
- Fix inline on parent resolved values (#135)
- Config input type (#138)
- refactor: drop unused field from Blueprint
- TValid Improvement (#139)
- chore(deps): update dependency dev.zio:zio-cli to v0.5.0 (#136)
- Feature: Server settings can be set via CLI (#140)
- feature: add n + 1 detection
- style: reorder methods
- feature: display n + 1 issues in the spec
