### PR TITLE
Fix: Use Scalar for Blueprint

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ val calibanVersion   = "2.2.1"
 val zioVersion       = "2.0.13"
 val zioJsonVersion   = "0.5.0"
 val rocksDB          = "0.4.2"
-val zioSchemaVersion = "0.4.10+3-6104a0e7-SNAPSHOT"
+val zioSchemaVersion = "0.4.11"
 
 val zioSchema           = "dev.zio"               %% "zio-schema"            % zioSchemaVersion
 val zioSchemaDerivation = "dev.zio"               %% "zio-schema-derivation" % zioSchemaVersion

--- a/runtime/src/main/scala/tailcall/runtime/lambda/Lambda.scala
+++ b/runtime/src/main/scala/tailcall/runtime/lambda/Lambda.scala
@@ -1,12 +1,11 @@
 package tailcall.runtime.lambda
 
-import caliban.Value
 import tailcall.runtime.JsonT
 import tailcall.runtime.lambda.Expression._
 import tailcall.runtime.model.Endpoint
 import tailcall.runtime.service.EvaluationContext.Binding
 import tailcall.runtime.service.{EvaluationRuntime, HttpContext}
-import zio.json.{EncoderOps, JsonCodec}
+import zio.json.JsonCodec
 import zio.schema.codec.JsonCodec.jsonCodec
 import zio.schema.{DynamicValue, Schema}
 import zio.{UIO, ZIO}
@@ -58,9 +57,6 @@ sealed trait Lambda[-A, +B] {
 }
 
 object Lambda {
-  implicit def calibanSchema[A, B]: caliban.schema.Schema[Any, A ~> B] =
-    caliban.schema.Schema.scalarSchema("Lambda", None, None, None, l => Value.StringValue(l.toJson))
-
   implicit def json[A, B]: JsonCodec[A ~> B] = jsonCodec[A ~> B](schema)
 
   implicit def schema[A, B]: Schema[A ~> B] = anySchema.asInstanceOf[Schema[A ~> B]]

--- a/runtime/src/main/scala/tailcall/runtime/model/Blueprint.scala
+++ b/runtime/src/main/scala/tailcall/runtime/model/Blueprint.scala
@@ -1,10 +1,10 @@
 package tailcall.runtime.model
 
-import caliban.{GraphQL, Value}
+import caliban.{GraphQL, ResponseValue, Value}
 import tailcall.runtime.lambda.{Expression, ~>}
 import tailcall.runtime.service.{GraphQLGenerator, HttpContext}
 import zio.ZIO
-import zio.json.{EncoderOps, JsonCodec}
+import zio.json.{DecoderOps, EncoderOps, JsonCodec}
 import zio.schema.{DeriveSchema, DynamicValue, Schema}
 
 import scala.annotation.tailrec
@@ -63,8 +63,13 @@ final case class Blueprint(definitions: List[Blueprint.Definition]) {
 }
 
 object Blueprint {
-  implicit val calibanSchema: caliban.schema.Schema[Any, Blueprint] = caliban.schema.Schema
-    .scalarSchema(name = "Blueprint", description = None, None, None, blueprint => Value.StringValue(blueprint.toJson))
+  implicit val calibanSchema: caliban.schema.Schema[Any, Blueprint] = caliban.schema.Schema.scalarSchema(
+    name = "Blueprint",
+    description = None,
+    None,
+    None,
+    _.toJson.fromJson[ResponseValue].getOrElse(Value.NullValue),
+  )
 
   implicit val schema: Schema[Blueprint] = DeriveSchema.gen[Blueprint]
 

--- a/runtime/src/main/scala/tailcall/runtime/model/Blueprint.scala
+++ b/runtime/src/main/scala/tailcall/runtime/model/Blueprint.scala
@@ -1,11 +1,10 @@
 package tailcall.runtime.model
 
-import caliban.GraphQL
+import caliban.{GraphQL, Value}
 import tailcall.runtime.lambda.{Expression, ~>}
 import tailcall.runtime.service.{GraphQLGenerator, HttpContext}
-import tailcall.runtime.transcoder.Transcoder
 import zio.ZIO
-import zio.json.JsonCodec
+import zio.json.{EncoderOps, JsonCodec}
 import zio.schema.{DeriveSchema, DynamicValue, Schema}
 
 import scala.annotation.tailrec
@@ -64,19 +63,12 @@ final case class Blueprint(definitions: List[Blueprint.Definition]) {
 }
 
 object Blueprint {
-  import caliban.schema.Schema.auto._
-  implicit def dynamicValueSchema: caliban.schema.Schema[Any, DynamicValue] =
-    caliban.schema.Schema.scalarSchema[DynamicValue](
-      name = "DynamicValue",
-      description = None,
-      specifiedBy = None,
-      directives = None,
-      makeResponse = dynamic => Transcoder.toResponseValue(dynamic).unwrap,
-    )
+  implicit val calibanSchema: caliban.schema.Schema[Any, Blueprint] = caliban.schema.Schema
+    .scalarSchema(name = "Blueprint", description = None, None, None, blueprint => Value.StringValue(blueprint.toJson))
 
-  implicit val calibanSchema: caliban.schema.Schema[Any, Blueprint] = { caliban.schema.Schema.gen[Any, Blueprint] }
-  implicit val schema: Schema[Blueprint]                            = DeriveSchema.gen[Blueprint]
-  implicit val codec: JsonCodec[Blueprint]                          = zio.schema.codec.JsonCodec.jsonCodec(schema)
+  implicit val schema: Schema[Blueprint] = DeriveSchema.gen[Blueprint]
+
+  implicit val codec: JsonCodec[Blueprint] = zio.schema.codec.JsonCodec.jsonCodec(schema)
 
   def decode(bytes: CharSequence): Either[String, Blueprint] = codec.decodeJson(bytes)
 


### PR DESCRIPTION
Represents Blueprint as a scalar. This makes its much faster and easier to query and mutate.